### PR TITLE
Add empty statements

### DIFF
--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -756,7 +756,7 @@ interpretStatement (CExpr Nothing _) = return (Rust.BlockExpr (Rust.Block [] Not
 ```
 
 Otherwise, the first argument to `interpretExpr` indicates whether the
-expression appears in a context where its result matters. In a st
+expression appears in a context where its result matters. In a statement
 expression, the result is discarded, so we pass `False`.
 
 ```haskell

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -748,8 +748,15 @@ A C statement might be as simple as a "statement expression", which
 amounts to a C expression followed by a semicolon. In that case we can
 translate the statement by just translating the expression.
 
-The first argument to `interpretExpr` indicates whether the expression
-appears in a context where its result matters. In a statement
+If the statement is empty, as in just a semicolon, we can just produce an empty
+block.
+
+```haskell
+interpretStatement (CExpr Nothing _) = return (Rust.BlockExpr (Rust.Block [] Nothing))
+```
+
+Otherwise, the first argument to `interpretExpr` indicates whether the
+expression appears in a context where its result matters. In a statement
 expression, the result is discarded, so we pass `False`.
 
 ```haskell

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -748,7 +748,7 @@ A C statement might be as simple as a "statement expression", which
 amounts to a C expression followed by a semicolon. In that case we can
 translate the statement by just translating the expression.
 
-If the statement is empty, as in just a semicolon, we can just produce an empty
+If the statement is empty, as in just a semicolon, we can produce an empty
 block.
 
 ```haskell
@@ -756,7 +756,7 @@ interpretStatement (CExpr Nothing _) = return (Rust.BlockExpr (Rust.Block [] Not
 ```
 
 Otherwise, the first argument to `interpretExpr` indicates whether the
-expression appears in a context where its result matters. In a statement
+expression appears in a context where its result matters. In a st
 expression, the result is discarded, so we pass `False`.
 
 ```haskell


### PR DESCRIPTION
Should be the straightforward fix #17. Tested it on the following:

``` c
int f() {
    ;
    for (int i = 0; i < 10;)
        i++;
    return 3;
}
```

 and got back

``` rust
pub unsafe fn f() -> i32 {
    { }
    {
        let mut i : i32 = 0i32;
        while i < 10i32 {
            i = i + 1;
        }
    }
    3i32
}
```

Not sure if we should also add some simplifying rules (to get rid of the `{ }`)... let me know what you think. Can't wait to start hacking on this project for real!
