### PR TITLE
Added support for compound literals.

### DIFF
--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -1817,6 +1817,20 @@ strings.
         in map (toUpper . intToDigit) [u, l]
 ```
 
+C99 compound literals are really not much different than an initializer
+list with the type of the thing we are initializing included.
+
+```haskell
+interpretExpr _ (CCompoundLit decl initials info) = do
+    ty <- typeName decl
+    final <- interpretInitializer ty (CInitList initials info)
+    return Result
+        { resultType = ty
+        , isMutable = Rust.Immutable
+        , result = final
+        }
+```
+
 GCC's "statement expression" extension translates pretty directly to
 Rust block expressions.
 


### PR DESCRIPTION
Should fix #12, at least insofar as `interpretInitializer` is complete.

``` c
int compound_lit() {
  return (int) {1} + (int) {3};
}
```

compiles to

``` rust
pub unsafe fn compound_lit() -> i32 { 1i32 + 3i32 }
```

---

With respect to `interpretInitializer` and partial initialization of structs: as I understand it, uninitialized fields should simply be implicitly initialized as with static storage duration. We already do implicitly initialization with static variables, but I don't think we do it right - our approach is just to set them equal to `0`, even if that fails with things like structs. For example,

``` c
static struct student 
{
  int id;
  float percentage;
} s;
```

compiles to

``` rust
#[derive(Clone, Copy)]
pub struct student {
    pub id : i32,
    pub percentage : f32,
}

#[no_mangle]
static mut s : student = 0;
```

but that doesn't compile with `rustc`. Aside from the obvious `error: main function not found`, we get

> struct.rs:8:26: 8:27 error: mismatched types:
> expected `student`,
>    found `_`
> (expected struct `student`, found integral variable) [E0308]
> struct.rs:8 static mut s : student = 0;

That looks like a bug.

Also, I'm not sure what we want to do if the object references itself during initialization. I'm thinking about this in the perspective of one struct field referencing another.

``` c
struct student s = { .id=s.id2, .id2=2 };
```

Since `s` hasn't been initialized yet, `.id=s.id2` means `s.id` can be any value. Rust doesn't permit this at all.

Anyways, what else am I missing?
