### PR TITLE
Add ghc 8.0.1 support

### DIFF
--- a/corrode.cabal
+++ b/corrode.cabal
@@ -16,7 +16,7 @@ library
                        Language.Rust.Corrode.C
   ghc-options:         -Wall -fwarn-incomplete-uni-patterns -pgmL markdown-unlit
   default-language:    Haskell2010
-  build-depends:       base >=4.8 && <4.9,
+  build-depends:       base >=4.8,
                        language-c >=0.4 && <0.6,
                        markdown-unlit,
                        pretty,
@@ -26,7 +26,7 @@ executable corrode
   main-is:             Main.lhs
   ghc-options:         -Wall -pgmL markdown-unlit
   default-language:    Haskell2010
-  build-depends:       base >=4.8 && <4.9,
+  build-depends:       base >=4.8,
                        bytestring,
                        corrode,
                        filepath,


### PR DESCRIPTION
fixes #39 

Tested on

```
Ubuntu 14.04
The Glorious Glasgow Haskell Compilation System, version 8.0.1
```

installed via binary from https://www.haskell.org/platform/linux.html#linux-generic

tested with the referenced gist
