### PR TITLE
Support For Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ install:
   - echo $PATH
   - cabal --version
   - ghc --version
+  - cabal install happy
+  - cabal install alex
   - cabal install --verbose
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,10 @@ before_install:
   - travis_retry cabal update
 
 install:
+  - echo $PATH
   - cabal --version
   - ghc --version
-  - cabal install --only-dependencies
+  - cabal install --verbose
 
 script:
   - true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# Use new container infrastructure to enable caching
+sudo: false
+
+language: haskell
+
+ghc:
+  - 7.10
+  - 8.1
+
+before_install:
+  - ghc --version
+  - cabal --version
+  - travis_retry cabal update
+
+script:
+  - cabal install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,15 @@ sudo: false
 language: haskell
 
 ghc:
-  - 7.10
-  - 8.1
+  - "7.10"
 
 before_install:
   - ghc --version
   - cabal --version
   - travis_retry cabal update
 
+install:
+  - cabal install --only-dependencies --enable-tests
+
 script:
-  - cabal install
+  - true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Sudo used for custom apt setup
 sudo: true
 
+# Add new environments to the build here:
 env:
  - GHCVER=7.10.1 CABALVER=1.22
  - GHCVER=head CABALVER=head
@@ -19,6 +20,7 @@ before_install:
   - export PATH=$HOME/.cabal/bin:$PATH
   - travis_retry cabal update
 
+# install happy and alex first, see: https://github.com/jameysharp/corrode/issues/57
 install:
   - echo $PATH
   - cabal --version
@@ -27,5 +29,6 @@ install:
   - cabal install alex
   - cabal install --verbose
 
+# TODO: Add an example or other tests.
 script:
   - true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+  - export PATH=$HOME/.cabal/bin:$PATH
   - travis_retry cabal update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: true
 # Add new environments to the build here:
 env:
  - GHCVER=7.10.1 CABALVER=1.22
+ - GHCVER=8.0.1 CABALVER=1.22
  - GHCVER=head CABALVER=head
 
 # Allow for develop branch to break

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
-# Use new container infrastructure to enable caching
-sudo: false
+# Sudo used for custom apt setup
+sudo: true
 
-language: haskell
+env:
+ - GHCVER=7.10.1 CABALVER=1.22
+ - GHCVER=head CABALVER=head
 
-ghc:
-  - "7.10"
+# Allow for develop branch to break
+matrix:
+  allow_failures:
+   - env: GHCVER=head CABALVER=head
 
+# Manually install ghc and cabal
 before_install:
-  - ghc --version
-  - cabal --version
+  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
   - travis_retry cabal update
 
 install:
-  - cabal install --only-dependencies --enable-tests
+  - cabal --version
+  - ghc --version
+  - cabal install --only-dependencies
 
 script:
   - true


### PR DESCRIPTION
Travis doesn't have support for anything recent like ghc 7.10. So a version is installed by hand (that is, without using Travis's built in `language: haskell` container.

Also I don't know what to run as a test, so the built passes if the `cabal install` works.
