### PR TITLE
Preliminary support for unions added.

### DIFF
--- a/src/Language/Rust/AST.hs
+++ b/src/Language/Rust/AST.hs
@@ -152,6 +152,7 @@ data Expr
     | Var Var
     | Path Path
     | StructExpr String [(String, Expr)] (Maybe Expr)
+    | UnionExpr String (String, Expr)
     | Call Expr [Expr]
     | MethodCall Expr Var [Expr]
     | Lambda [Var] Expr
@@ -228,6 +229,8 @@ instance Pretty Expr where
             : punctuate (text ",") ([ nest 4 (text name <> text ":" <+> pPrint val) | (name, val) <- fields ] ++ maybe [] (\b -> [ text ".." <> pPrint b ]) base)
             ++ [text "}"]
             )
+        UnionExpr str (name, val) -> sep
+            [ text str <+> text "{", nest 4 (text name <> text ":" <+> pPrint val), text "}" ]
         Call f args -> cat
             ( pPrintPrec l 13 f <> text "("
             : punctuate (text ",") (map (nest 4 . pPrint) args)

--- a/src/Language/Rust/AST.hs
+++ b/src/Language/Rust/AST.hs
@@ -82,6 +82,7 @@ data ItemKind
     = Function [FunctionAttribute] String [(Mutable, Var, Type)] Type Block
     | Static Mutable Var Type Expr
     | Struct String [(String, Type)]
+    | Union String [(String, Type)]
     | Extern [ExternItem]
     | Use String
     | Enum String [Enumerator]
@@ -101,6 +102,10 @@ instance Pretty ItemKind where
     pPrint (Struct name fields) =
         text "struct" <+> text name <+> text "{" $+$
         nest 4 (vcat [ text "pub" <+> text field <+> text ":" <+> pPrint ty <> text "," | (field, ty) <- fields ]) $+$
+        text "}"
+    pPrint (Union name cases) =
+        text "union" <+> text name <+> text "{" $+$
+        nest 4 (vcat [ text "pub" <+> text field <+> text ":" <+> pPrint ty <> text "," | (field, ty) <- cases ]) $+$
         text "}"
     pPrint (Extern defs) = vcat
         ( text "extern {"


### PR DESCRIPTION
This is really _far_ from complete, but it starts addressing #22 by filling in everything straightforward. Here are the issues AFAICT
- We cannot yet derive `Copy` and `Clone` for unions, but support for that [is pending](https://github.com/rust-lang/rust/pull/36384) (incredibly fast given how recent an addition unions are!).
- We'll need to add `#![feature(untagged_unions)]` to the top of files (I don't think we currently have anything to do this - if we don't it'd be worth it to make it good).
- The can of worms that was struct initialization needs to be reopened. I'll take a look at the C99 spec. I'm _hoping_ that when there are multiple (named) initializers in the initializer list for a union in C99, we simply ignore all except the last one (even if the previous ones are bigger), and at least [clang](https://gcc.godbolt.org/#compilers:!%28%28compiler:clang380,options:%27-O2+-Wall+-xc%27,sourcez:MQSwdgxgNgrgJgUwAQB4DOAXOID2A6ACwD4AoEzAJxggyQBUkBvEpJcWjARgG4W2wOAJl4BfXpWq0Aykz4Sa9JGh4kxZdkgC2AQ3AAKAG44QcAJQlmrebQa0AvEyR4MgpA9dqrGKgplo3sqyseMoBGAA0fMHKzpwBnJGsnkgADhTsAGZ6AEQApHBI%2BQA6YNnhSiGcseVolc6CpqJAAA%3D%29%29,filterAsm:%28commentOnly:!t,directives:!t,labels:!t%29,version:3) seems to agree... I'm also hoping that the rust unions are also initialized with an extra empty space zeroed out. If all that works out as expected, I'll still need to find a nice way of expressing union based initializers - something like
  
  ``` haskell
  data Initializer
     = StructInitializer (Maybe Rust.Expr) (IntMap.IntMap Initializer)
     = UnionInitializer Int Initializer
  ```

Is there anything else I'm missing here? I think there is something to do with incomplete types that you did for structs that also applies to unions. I'm thinking of [this](https://github.com/jameysharp/corrode/commit/3346deb4005e12bc27e40f63132b62953859e9e3)...
