### PR TITLE
Translate __FILE__ and __LINE__

### DIFF
--- a/Main.md
+++ b/Main.md
@@ -74,7 +74,7 @@ main = dieOnError $ do
                     { outputFile = Nothing
                     , extraOptions = filter (not . ("-O" `isPrefixOf`)) (extraOptions rawArgs)
                     })
-                (map Undefine ["__BLOCKS__"])
+                (map Undefine ["__BLOCKS__", "__FILE__", "__LINE__"])
     ```
 
 1. Run the preprocessor&mdash;except that if the input appears to have

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -264,6 +264,21 @@ getSymbolIdent ident = lift $ do
             )))
         | w <- [16, 32, 64]
         ]
+        ++
+        [ ("__FILE__",
+            ("file!().as_ptr()",
+                Just (Rust.Immutable,
+                    IsFunc (IsPtr Rust.Immutable charType)
+                        [(Nothing, IsInt Unsigned (BitWidth 32))] False
+            )))
+        ,
+          ("__LINE__",
+            ("line!()",
+                Just (Rust.Immutable,
+                    IsFunc (IsInt Unsigned (BitWidth 32))
+                        [(Nothing, IsInt Unsigned (BitWidth 32))] False
+            )))
+        ]
 
 getTypedefIdent :: Ident -> EnvMonad (String, Maybe IntermediateType)
 getTypedefIdent ident = lift $ do

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -268,15 +268,13 @@ getSymbolIdent ident = lift $ do
         [ ("__FILE__",
             ("file!().as_ptr()",
                 Just (Rust.Immutable,
-                    IsFunc (IsPtr Rust.Immutable charType)
-                        [(Nothing, IsInt Unsigned (BitWidth 32))] False
+                    IsPtr Rust.Immutable charType
             )))
         ,
           ("__LINE__",
             ("line!()",
                 Just (Rust.Immutable,
-                    IsFunc (IsInt Unsigned (BitWidth 32))
-                        [(Nothing, IsInt Unsigned (BitWidth 32))] False
+                    IsInt Unsigned (BitWidth 32)
             )))
         ]
 


### PR DESCRIPTION
- Stop preprocessor from defining **FILE** and **LINE**
- Translate them to file!().as_ptr() and line!() respectively
