### PR TITLE
Turn off _FORTIFY_SOURCE.

### DIFF
--- a/Main.md
+++ b/Main.md
@@ -69,12 +69,14 @@ main = dieOnError $ do
    optimization flags that make GCC define preprocessor symbols.
 
     ```haskell
+        let defines = [Define "_FORTIFY_SOURCE" "0"]
+        let undefines = map Undefine ["__BLOCKS__", "__FILE__", "__LINE__"]
         let args = foldl addCppOption
                 (rawArgs
                     { outputFile = Nothing
                     , extraOptions = filter (not . ("-O" `isPrefixOf`)) (extraOptions rawArgs)
                     })
-                (map Undefine ["__BLOCKS__", "__FILE__", "__LINE__"])
+                (defines ++ undefines)
     ```
 
 1. Run the preprocessor&mdash;except that if the input appears to have


### PR DESCRIPTION
Without disabling this, calls to `memcpy` and similar functions
get renamed into things like `__builtin___memcpy_chk` which aren't
present and result in errors during corrosion.

This feature is enabled by default on macOS and makes using corrode
on macOS more difficult than it needs to be.

Fix issue #84.