### PR TITLE
Apply renames to struct initializer fields.

### DIFF
--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -1036,7 +1036,7 @@ objectFromDesignators ty desigs = Just <$> go ty desigs (Base ty)
     go :: CType -> [CDesignator] -> Designator -> EnvMonad s Designator
     go _ [] obj = pure obj
     go (IsStruct name fields) (d@(CMemberDesig ident _) : ds) obj = do
-        case span (\ (field, _) -> identToString ident /= field) fields of
+        case span (\ (field, _) -> applyRenames ident /= field) fields of
             (_, []) -> badSource d ("designator for field not in struct " ++ name)
             (earlier, (_, ty') : rest) ->
                 go ty' ds (From ty' (length earlier) (map snd rest) obj)


### PR DESCRIPTION
Struct fields might have names that are reserved keywords in Rust
and as such, need to be renamed. This makes sure that they are
renamed for struct initializer fields (and probably other scenarios).

Fix issue #83.