### PR TITLE
Replace UTF-8 encoded character with ascii

### DIFF
--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -2217,7 +2217,7 @@ explicitly ignoring the result, meaning the expression is only intended
 to be evaluated for its side effects. It's commonly used in older code
 to suppress over-zealous compiler warnings, and continues to be used in
 certain special cases such as glibc's implementation of the assert
-macro. A naïve translation of this idiom produces invalid Rust, so we
+macro. A naive translation of this idiom produces invalid Rust, so we
 special-case it to simply evaluate the subexpression without demanding
 its result.
 


### PR DESCRIPTION
When running 'stack install' the "ï" in "naïve" would fail with:

"markdown-unlit: src/Language/Rust/Corrode/C.lhs: hGetContents: invalid
argument (invalid byte sequence)"

in cases where the locale was not set to UTF-8. To avoid failures when
building switch to the ascii character "i" instead.

Resolves #96 