### PR TITLE
Add a Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install git ghc haskell-stack -y
+RUN git clone https://github.com/jameysharp/corrode.git
+RUN cd corrode && stack build


### PR DESCRIPTION
I actually spent an hour looking for a distro that lets me build corrode because `stack` was really difficult to work with (Debian for example expected `stack setup`, but compilation failed because of lack of `-fPIC`). I believe that having a Dockerfile could simplify the process of running corrode.