### PR TITLE
Fix build with macOS system headers

### DIFF
--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -2933,6 +2933,7 @@ castTo target (Result { resultType = IsArray mut _ el, result = source }) =
         Rust.Immutable -> "as_ptr"
         Rust.Mutable -> "as_mut_ptr"
 castTo IsBool source = toBool source
+castTo target Result { resultType = ty, resultMutable = mut, result = (Rust.BlockExpr (Rust.Block statements (Just tail_))) } = Rust.BlockExpr (Rust.Block statements (Just (castTo target Result {resultType = ty, resultMutable = mut, result = tail_})))
 castTo target source = Rust.Cast (result source) (toRustType target)
 ```
 

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -569,7 +569,8 @@ don't derive `Copy` or `Clone` for it.
         ]
     incompleteTypes = outputIncomplete output `Set.difference` completeTypes
     incompleteItems =
-        [ Rust.Item [] Rust.Public (Rust.Enum name [])
+        let attrs = [ Rust.Attribute "allow(non_camel_case_types)" ] in
+        [ Rust.Item attrs Rust.Public (Rust.Enum name [])
         | name <- Set.toList incompleteTypes
         ]
 ```

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -569,7 +569,7 @@ don't derive `Copy` or `Clone` for it.
         ]
     incompleteTypes = outputIncomplete output `Set.difference` completeTypes
     incompleteItems =
-        [ Rust.Item [] Rust.Private (Rust.Enum name [])
+        [ Rust.Item [] Rust.Public (Rust.Enum name [])
         | name <- Set.toList incompleteTypes
         ]
 ```

--- a/src/Language/Rust/Idiomatic.hs
+++ b/src/Language/Rust/Idiomatic.hs
@@ -33,6 +33,7 @@ tailBlock :: Rust.Block -> Rust.Block
 tailBlock (Rust.Block b (Just (tailExpr -> Just e))) = Rust.Block b e
 -- If there's no final expression but the final statement consists of an
 -- expression that makes sense in the tail position, move it.
+tailBlock (Rust.Block (unsnoc -> Just (b, Rust.Stmt (tailExpr -> Just (Just (Rust.BlockExpr (Rust.Block stmts ret)))))) Nothing) = Rust.Block (b ++ stmts) ret
 tailBlock (Rust.Block (unsnoc -> Just (b, Rust.Stmt (tailExpr -> Just e))) Nothing) = Rust.Block b e
 -- Otherwise, leave this block unchanged.
 tailBlock b = b


### PR DESCRIPTION
This allows for builds on macOS, using the `assert.h`, `locale.h`, `setjmp.h`, `signal.h`, `stdarg.h`, `stdio.h`, `stdlib.h` and `string.h` system headers. `ctype.h`, `math.h` and `time.h` still do not translate.

It still requires 
```c
#define _Nullable
#define _Nonnull
#define __CUDACC__
```
to be added to the top of any input source file.