### PR TITLE
Docker: add corrode to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:16.04
 RUN apt-get update && apt-get install git ghc haskell-stack -y
 RUN git clone https://github.com/jameysharp/corrode.git
-RUN cd corrode && stack build
+RUN cd corrode && stack build && stack install
+ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
By adding corrode to the docker container PATH you can use corrode run more easily. For example:

```
docker run -v <local folder path>:<container mount point> <container hash> corrode <absolute filepath>
```

how I use the docker file:
```
git clone https://github.com/jameysharp/corrode && cd corrode
docker build .
docker run -v ~/git:/git bf1426231b60 corrode /git/project/main.c
```
