### PR TITLE
Bump language-c to 0.6

### DIFF
--- a/corrode.cabal
+++ b/corrode.cabal
@@ -20,7 +20,7 @@ library
   build-depends:       base >=4.8,
                        array >= 0.4,
                        containers >= 0.5,
-                       language-c >=0.4 && <0.6,
+                       language-c >=0.6 && <0.7,
                        markdown-unlit,
                        pretty,
                        transformers
@@ -33,7 +33,7 @@ executable corrode
                        bytestring,
                        corrode,
                        filepath,
-                       language-c >=0.4 && <0.6,
+                       language-c >=0.6 && <0.7,
                        markdown-unlit,
                        pretty,
                        transformers >=0.2


### PR DESCRIPTION

Changes:

* `language-c` can now deal with OSX header peculiarities and more C11 stuff. 
  fixes #109 , fixes #82 , fixes #81 , and probably others that I didn't notice.

* `language-c` now has an AST representation for `_Static_assert` which corrode doesn't know what to do with.  I added cases so that at least the incomplete pattern matches are matched, but they pretty much just call `error`

* `partitionDeclSpecs` now returns a 6-tuple (used to be 5) where the last two components are inline+noreturn function specifiers and alignment specifiers, respectively.  Corrode used to ignore the inline specifier, so no functional change there.

* The GCC math intrinsics (such as `__builtin_fabsf` from #99) are still not supported 
