### PR TITLE
Generate Clone implementations which can handle large array fields

### DIFF
--- a/src/Language/Rust/AST.hs
+++ b/src/Language/Rust/AST.hs
@@ -128,6 +128,7 @@ data ItemKind
     | Extern [ExternItem]
     | Use String
     | Enum String [Enumerator]
+    | CloneImpl Type
     deriving Show
 
 instance Pretty ItemKind where
@@ -156,6 +157,12 @@ instance Pretty ItemKind where
         text "enum" <+> text name <+> text "{" $+$
         nest 4 (vcat [ pPrint enum <> text "," | enum <- enums ]) $+$
         text "}"
+    pPrint (CloneImpl ty) =
+        hsep [text "impl", text "Clone", text "for", pPrint ty] <+> text "{" $+$
+            nest 4 (text "fn" <+> text "clone" <> parens (text "&self") <+> text "{" <+>
+                nest 4 (text "*self") <+>
+                text "}") $+$
+            text "}"
 
 data ExternItem
     = ExternFn String [(Var, Type)] Bool Type


### PR DESCRIPTION
Rust arrays don't actually implement `Clone` for sizes > 32 so any struct which contain arrays larger than 32 will not be able to derive `Clone`. Arrays do however always derive `Copy` (as long as they contain copy elements) so we can generate a `Clone` impl which uses the `Copy` impl instead.

Since I don't see any reason now for the AST to generate arbitrary `impl` blocks I only added the `CloneImpl` constructor which is a bit of a hack but should do the trick for the moment.

The example below will now work.
```c
struct Test
{
    int x[100];
};

int main()
{
    struct Test x = {};
    struct Test y = x;
}
```