### PR TITLE
Cache haskell artifacts to get faster travis build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 # Sudo used for custom apt setup
 sudo: true
 
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
 # Add new environments to the build here:
 env:
  - GHCVER=7.10.1 CABALVER=1.22


### PR DESCRIPTION
Not sure if this works but the travis script on https://docs.haskellstack.org/en/stable/travis_ci/ has these directories cached.