### PR TITLE
Docker: Upgrade ubuntu for access to new GHC.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:17.04
 RUN apt-get update && apt-get install git ghc haskell-stack -y
 RUN git clone https://github.com/jameysharp/corrode.git
 RUN cd corrode && stack build && stack install


### PR DESCRIPTION
Docker was broken because stack required a GHC version newer than the one included in 16.04.