### PR TITLE
Handle cases like int table[1 << HASHBITS][WIDTH*HEIGHT][MAXSIZE + 1]

### DIFF
--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -2960,6 +2960,18 @@ better because it preserves more of the programmer's intent.
 ```haskell
 interpretConstExpr :: CExpr -> EnvMonad s Integer
 interpretConstExpr (CConst (CIntConst (CInteger v _ _) _)) = return v
+interpretConstExpr (CBinary CAddOp lhs rhs _) = do
+    lhs' <- interpretConstExpr lhs
+    rhs' <- interpretConstExpr rhs
+    return (lhs' + rhs')
+interpretConstExpr (CBinary CMulOp lhs rhs _) = do
+    lhs' <- interpretConstExpr lhs
+    rhs' <- interpretConstExpr rhs
+    return (lhs' * rhs')
+interpretConstExpr (CBinary CShlOp lhs rhs _) = do
+    lhs' <- interpretConstExpr lhs
+    rhs' <- interpretConstExpr rhs
+    return (lhs' * 2^rhs')
 interpretConstExpr expr = unimplemented expr
 ```
 

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -371,13 +371,20 @@ getSymbolIdent ident = do
             , result = Rust.Deref (Rust.Lit (Rust.LitByteStr (name' ++ "\NUL")))
             }
     builtinSymbols =
-        [ ("__builtin_bswap" ++ show w, Result
+        [ (c, Result
             { resultType = IsFunc (IsInt Unsigned (BitWidth w))
                 [(Nothing, IsInt Unsigned (BitWidth w))] False
             , resultMutable = Rust.Immutable
-            , result = Rust.Path (Rust.PathSegments ["u" ++ show w, "swap_bytes"])
+            , result = Rust.Path (Rust.PathSegments ["u" ++ show w, rust])
             })
-        | w <- [16, 32, 64]
+            | (c, rust, w) <- [
+                ("__builtin_bswap16", "swap_bytes", 16),
+                ("__builtin_bswap32", "swap_bytes", 32),
+                ("__builtin_bswap64", "swap_bytes", 64),
+                ("__builtin_clzll", "leading_zeros", 64),
+                ("__builtin_ctzll", "trailing_zeros", 64),
+                ("__builtin_popcountll", "count_ones", 64)
+            ]
         ]
         ++
         [ ("__FILE__", Result

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -2358,6 +2358,11 @@ on whether the pointer was to a mutable value.
                 , resultMutable = mut'
                 , result = Rust.Deref (result expr')
                 }
+            IsArray mut' _ ty' -> return Result
+                { resultType = ty'
+                , resultMutable = mut'
+                , result = Rust.Index (result expr') 0
+                }
             IsFunc{} -> return expr'
             _ -> badSource node "dereference of non-pointer"
 ```

--- a/src/Language/Rust/Corrode/C.md
+++ b/src/Language/Rust/Corrode/C.md
@@ -340,6 +340,7 @@ applyRenames ident = case identToString ident of
     "main" -> "_c_main"
     "match" -> "match_"
     "mod" -> "mod_"
+    "move" -> "move_"
     "proc" -> "proc_"
     "type" -> "type_"
     "where" -> "where_"


### PR DESCRIPTION
...by defining more cases of interpretConstExpr. This covers a simple case from #133, though it's not clear to me that this approach can successfully solve the whole issue.
TIA for any feedback.