### PR TITLE
Suggest to run cabal update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ navigating to the `corrode` directory, installing the `happy` and `alex` tools,
 and then building and installing the `corrode` package:
 
 ```
+cabal update
 cabal install happy
 cabal install alex
 cabal install


### PR DESCRIPTION
A good deal of people would install cabal and friends just to have corrode, better add another step so they won't be surprised if they dare to paste the commands and leave it unattended.